### PR TITLE
Added deepsek-r1 models support, added type system for wrapped function

### DIFF
--- a/examples/1.5_get_started.py
+++ b/examples/1.5_get_started.py
@@ -15,7 +15,7 @@ class Result(BaseModel):
 
 
 @gpt35_func.async_call
-def fool2(emotion) -> Result:  # type: ignore
+def fool2(emotion: str) -> Result:  # type: ignore
     """
     You need to output an emoji, which is {emotion}
     """
@@ -41,7 +41,7 @@ print(set_bound_func.async_funcs)  # type: ignore
 
 
 @set_bound_func.async_call
-def fool3(emotion) -> Result:  # type: ignore
+def fool3(emotion: str) -> Result:  # type: ignore
     """
     You need to output an emoji, which is {emotion}
     """

--- a/examples/1.7_get_started.py
+++ b/examples/1.7_get_started.py
@@ -19,7 +19,7 @@ def fool() -> Result:  # type: ignore
 
 
 @llama2_func
-def fool2(emotion) -> Result:  # type: ignore
+def fool2(emotion: str) -> Result:  # type: ignore
     """
     You need to randomly output an emoji, which should be {emotion}
     """

--- a/examples/1_get_started.py
+++ b/examples/1_get_started.py
@@ -21,7 +21,7 @@ def fool() -> Result:  # type: ignore
 
 
 @gpt35_func
-def fool2(emotion) -> Result:  # type: ignore
+def fool2(emotion: str) -> Result:  # type: ignore
     """
     You need to randomly output an emoji, which should be {emotion}
     """

--- a/llm_as_function/__init__.py
+++ b/llm_as_function/__init__.py
@@ -13,7 +13,14 @@ llama3_3_func = LLMFunc(temperature=0.1, model="llama3.3", has_tool_support=True
 llama3_2_1b_func = LLMFunc(temperature=0.1, model="llama3.2.1b", has_tool_support=True, has_structured_output=True)
 qwq_func = LLMFunc(temperature=0.1, model="krtkygpta/qwq", has_tool_support=True, has_structured_output=True)
 qwen2_1_5b_func = LLMFunc(temperature=0.1, model="qwen2:1.5b", has_tool_support=True, has_structured_output=True)  # This has tool support but i haven't be able to relabily use it
+deepseek_r1_1_5b_func = LLMFunc(temperature=0.1, model="deepseek-r1:1.5b", has_tool_support=True, has_structured_output=True)
+deepseek_r1_7b_func = LLMFunc(temperature=0.1, model="deepseek-r1:7b", has_tool_support=True, has_structured_output=True)
+deepseek_r1_8b_func = LLMFunc(temperature=0.1, model="deepseek-r1:8b", has_tool_support=True, has_structured_output=True)
+deepseek_r1_14b_func = LLMFunc(temperature=0.1, model="deepseek-r1:14b", has_tool_support=True, has_structured_output=True)
+deepseek_r1_32b_func = LLMFunc(temperature=0.1, model="deepseek-r1:32b", has_tool_support=True, has_structured_output=True)
+deepseek_r1_70b_func = LLMFunc(temperature=0.1, model="deepseek-r1:70b", has_tool_support=True, has_structured_output=True)
+deepseek_r1_671b_func = LLMFunc(temperature=0.1, model="deepseek-r1:671b", has_tool_support=True, has_structured_output=True)
 
 __author__ = "Jianbai Ye"
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 __url__ = "https://github.com/gusye1234/llm-as-function"

--- a/llm_as_function/llm_func.py
+++ b/llm_as_function/llm_func.py
@@ -38,7 +38,7 @@ T = TypeVar("T")
 
 def model_factory(model_name: str) -> Literal["openai", "ollama"]:
     OPENAI_STARTS_WITH = ["gpt"]
-    OLLAMA_STARTS_WITH = ["llama", "krtkygpta/qwq", "qwen"]
+    OLLAMA_STARTS_WITH = ["llama", "krtkygpta/qwq", "qwen", "deepseek"]
 
     if any(model_name.startswith(prefix) for prefix in OPENAI_STARTS_WITH):
         return "openai"


### PR DESCRIPTION
This PR mainly includes the addition of deepseek-r1 series of models. It also includes type system for wrapped functions. Now wrapped functions will have the correct types.

For example:
```python
@llama2_func
def fool2(emotion: str) -> Result:  # type: ignore
    """
    You need to randomly output an emoji, which should be {emotion}
    """
    pass
```

**fool2** -> Type used to be junk leftover from the decorator now it is `(function) def fool2(emotion: str) -> Final`